### PR TITLE
Webpack loader refactor #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "vue-loader": "^9.8.1",
     "vue-style-loader": "^1.0.0",
     "webpack": "^1.13.3",
+    "webpack-combine-loaders": "^2.0.3",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-dev-server": "^1.16.2",
     "webpack-hot-middleware": "^2.12.2",

--- a/webpack/build/webpack.build.js
+++ b/webpack/build/webpack.build.js
@@ -6,7 +6,7 @@ var webpack = require('webpack');
 var merge = require('webpack-merge');
 var loaders = require('./loaders');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
-
+var combineLoaders = require('webpack-combine-loaders')
 
 const config = merge(baseWebpackConfig, {
   devtool: settings.productionSourceMap ? '#source-map' : false,
@@ -16,7 +16,22 @@ const config = merge(baseWebpackConfig, {
   },
   vue: {
     loaders: {
-      css: ExtractTextPlugin.extract('vue-style-loader', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss')
+      css: ExtractTextPlugin.extract(
+        'vue-style-loader',
+        combineLoaders([
+          {
+            loader: 'css-loader',
+            query: {
+              modules: true,
+              importLoaders: 1,
+              localIdentName: '[name]__[local]___[hash:base64:5]'
+            }
+          },
+          {
+            loader: 'postcss-loader'
+          }
+        ])
+      )
     }
   }
 });

--- a/webpack/dev/loaders.js
+++ b/webpack/dev/loaders.js
@@ -1,4 +1,21 @@
+var combineLoaders = require('webpack-combine-loaders')
+
 module.exports = [{
   test: /\.css$/,
-  loader: 'style-loader!css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader',
+  loader: combineLoaders([
+    {
+      loader: 'style-loader'
+    },
+    {
+      loader: 'css-loader',
+      query: {
+        modules: true,
+        importLoaders: 1,
+        localIdentName: '[name]__[local]___[hash:base64:5]'
+      }
+    },
+    {
+      loader: 'postcss-loader'
+    }
+  ])
 }];


### PR DESCRIPTION
Uses webpack-combine-loaders to combine multiple loaders, allowing to write query objects instead of a single string