### PR TITLE
refactor(css module): change hash for dev and production

### DIFF
--- a/webpack/build/webpack.build.js
+++ b/webpack/build/webpack.build.js
@@ -24,7 +24,7 @@ const config = merge(baseWebpackConfig, {
             query: {
               modules: true,
               importLoaders: 1,
-              localIdentName: '[name]__[local]___[hash:base64:5]'
+              localIdentName: '[hash:base64:5]'
             }
           },
           {

--- a/webpack/vue.js
+++ b/webpack/vue.js
@@ -6,7 +6,7 @@ module.exports = {
     html: 'vue-loader/lib/template-compiler'
   },
   cssModules: {
-    localIdentName: '[name]__[local]___[hash:base64:5]--[hash:base64:5]',
+    localIdentName: '[name]__[local]__[hash:base64:5]',
     camelCase: true
   },
   postcss


### PR DESCRIPTION
development needs to be more readable
production can be only hash, in order to save space and have a smaller css file

closes #46